### PR TITLE
Solve timing issue using Chipdrive Micro 120 V4.30 (buffered RS232) and Jameica/Hibiscus with recent Ubuntu 18.04

### DIFF
--- a/src/driver/ifd_towitoko.c
+++ b/src/driver/ifd_towitoko.c
@@ -34,7 +34,7 @@
  */
 
 #define IFD_TOWITOKO_TIMEOUT             1000
-#define IFD_TOWITOKO_DELAY               0
+#define IFD_TOWITOKO_DELAY               1
 #define IFD_TOWITOKO_BAUDRATE            9600
 #define IFD_TOWITOKO_PS                  15
 #define IFD_TOWITOKO_MAX_TRANSMIT        255

--- a/src/driver/io_serial.c
+++ b/src/driver/io_serial.c
@@ -596,7 +596,12 @@ IO_Serial_Write (IO_Serial * io, unsigned delay, unsigned size, BYTE * data)
 
   for (count = 0; count < size; count += to_send)
     {
+
+#ifdef DEBUG_SEND_ONE
       to_send = (delay? 1: size);
+#else
+      to_send = size;
+#endif
 
       if (IO_Serial_WaitToWrite (io->fd, delay, 1000))
 	{


### PR DESCRIPTION
For me, communication need delay on write while mirgrating from Ubunutu 14.04-HWE to Ubuntu 18.04 or HBCI card will not be detected.

Setting delay to 1ms solve the issue for me. I modify  IO_Serial_Write()  to send the whole buffer at one instead of one-by-one resulting in a one-time delay.